### PR TITLE
Add model routing toggles

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -1,4 +1,3 @@
-import { MODEL } from "@/config/constants";
 import { modelConfig } from "@/config/tools-config";
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
@@ -52,6 +51,9 @@ export async function POST(request: Request) {
     } else if (modelPreference === 'fast') {
       selectedModel = 'gpt-4.1'; // Force GPT-4.1 when fast toggle is on
       console.log("Using GPT-4.1 model (fast toggle enabled)");
+    } else if (modelPreference === 'search') {
+      selectedModel = 'sonar-small-online'; // Use Perplexity Sonar when web search toggle is on
+      console.log("Using Perplexity Sonar model (web search enabled)");
     } else {
       // Automatic selection when no toggle preference is set
       selectedModel = selectModel(messages);

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -5,10 +5,18 @@ import useConversationStore from "@/stores/useConversationStore";
 import { Item, processMessages } from "@/lib/assistant";
 
 export default function Assistant() {
-  const { chatMessages, addConversationItem, addChatMessage, setAssistantLoading } =
-    useConversationStore();
+  const {
+    chatMessages,
+    addConversationItem,
+    addChatMessage,
+    setAssistantLoading,
+  } = useConversationStore();
 
-  const handleSendMessage = async (message: string, files?: any[], modelPreference?: 'fast' | 'reasoning') => {
+  const handleSendMessage = async (
+    message: string,
+    files?: any[],
+    modelPreference?: 'fast' | 'reasoning' | 'search'
+  ) => {
     if (!message.trim() && (!files || files.length === 0)) return;
 
     // Create content array that includes text and files
@@ -73,7 +81,7 @@ export default function Assistant() {
     } as any;
     try {
       addConversationItem(approvalItem);
-      await processMessages(modelPreference);
+      await processMessages();
     } catch (error) {
       console.error("Error sending approval response:", error);
     }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -9,11 +9,15 @@ import ToolStatusIndicator from "./tool-status-indicator";
 import { Item, McpApprovalRequestItem, ToolCallItem } from "@/lib/assistant";
 import LoadingMessage from "./loading-message";
 import useConversationStore from "@/stores/useConversationStore";
-import { Paperclip, X, ArrowUp, Zap, Search, Globe, Square } from "lucide-react";
+import { Paperclip, X, ArrowUp, Zap, Globe, Square } from "lucide-react";
 
 interface ChatProps {
   items: Item[];
-  onSendMessage: (message: string, files?: any[], modelPreference?: 'fast' | 'reasoning') => void;
+  onSendMessage: (
+    message: string,
+    files?: any[],
+    modelPreference?: 'fast' | 'reasoning' | 'search'
+  ) => void;
   onApprovalResponse: (approve: boolean, id: string) => void;
 }
 
@@ -60,7 +64,7 @@ const Chat: React.FC<ChatProps> = ({
     if (!inputMessageText.trim() && attachedFiles.length === 0) return;
     
     try {
-      let messageContent = inputMessageText.trim();
+      const messageContent = inputMessageText.trim();
       let uploadedFiles = [];
 
       // Process files if any are attached
@@ -116,9 +120,13 @@ const Chat: React.FC<ChatProps> = ({
           console.log("Note: Conversations with images are not saved to prevent storage issues");
         }
         onSendMessage(
-          messageContent || "Please analyze the attached files.", 
+          messageContent || "Please analyze the attached files.",
           uploadedFiles,
-          useReasoningModel ? 'reasoning' : 'fast'
+          webSearchEnabled
+            ? 'search'
+            : useReasoningModel
+            ? 'reasoning'
+            : 'fast'
         );
       }
       
@@ -133,7 +141,7 @@ const Chat: React.FC<ChatProps> = ({
       console.error("Error sending message:", error);
       alert("Failed to upload files. Please try again.");
     }
-  }, [inputMessageText, attachedFiles, onSendMessage]);
+  }, [inputMessageText, attachedFiles, onSendMessage, useReasoningModel, webSearchEnabled]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -76,7 +76,7 @@ export const handleTurn = async (
   messages: any[],
   tools: any[],
   onMessage: (data: any) => void,
-  modelPreference?: 'fast' | 'reasoning',
+  modelPreference?: 'fast' | 'reasoning' | 'search',
   abortController?: AbortController
 ) => {
   try {
@@ -142,7 +142,9 @@ export const handleTurn = async (
   }
 };
 
-export const processMessages = async (modelPreference?: 'fast' | 'reasoning') => {
+export const processMessages = async (
+  modelPreference?: 'fast' | 'reasoning' | 'search'
+) => {
   const {
     chatMessages,
     conversationItems,


### PR DESCRIPTION
## Summary
- support extra `search` model preference in chat
- route `search` preference to Perplexity Sonar model
- allow UI to choose between fast, reasoning, and search modes

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: error TS2504, TS2339, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685713e73d9c8324952f3ef78bd143e4